### PR TITLE
Simplify iteration over results

### DIFF
--- a/maximum_cut.py
+++ b/maximum_cut.py
@@ -53,16 +53,14 @@ response = sampler.sample_qubo(Q,
                                chain_strength=chainstrength,
                                num_reads=numruns,
                                label='Example - Maximum Cut')
-energies = iter(response.data())
 
 # ------- Print results to user -------
 print('-' * 60)
 print('{:>15s}{:>15s}{:^15s}{:^15s}'.format('Set 0','Set 1','Energy','Cut Size'))
 print('-' * 60)
-for line in response:
-    S0 = [k for k,v in line.items() if v == 0]
-    S1 = [k for k,v in line.items() if v == 1]
-    E = next(energies).energy
+for sample, E in response.data(fields=['sample','energy']):
+    S0 = [k for k,v in sample.items() if v == 0]
+    S1 = [k for k,v in sample.items() if v == 1]
     print('{:>15s}{:>15s}{:^15s}{:^15s}'.format(str(S0),str(S1),str(E),str(int(-1*E))))
 
 # ------- Display results to user -------

--- a/maximum_cut_ising.py
+++ b/maximum_cut_ising.py
@@ -49,16 +49,14 @@ response = sampler.sample_ising(h, J,
                                 chain_strength=chainstrength,
                                 num_reads=numruns,
                                 label='Example - Maximum Cut Ising')
-energies = iter(response.data())
 
 # ------- Print results to user -------
 print('-' * 60)
 print('{:>15s}{:>15s}{:^15s}{:^15s}'.format('Set 0','Set 1','Energy','Cut Size'))
 print('-' * 60)
-for line in response:
-    S0 = [k for k,v in line.items() if v == -1]
-    S1 = [k for k,v in line.items() if v == 1]
-    E = next(energies).energy
+for sample, E in response.data(fields=['sample','energy']):
+    S0 = [k for k,v in sample.items() if v == -1]
+    S1 = [k for k,v in sample.items() if v == 1]
     print('{:>15s}{:>15s}{:^15s}{:^15s}'.format(str(S0),str(S1),str(E),str(int((6-E)/2))))
 
 # ------- Display results to user -------


### PR DESCRIPTION
Minor simplification for iteration over samples and energies.  Removes the line `energies = iter(response.data())`, which I found to be a little bit misleading as it is not just an iterator over energies.