### PR TITLE
Prepare for codespaces

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -34,18 +34,17 @@
 		// Configure properties specific to VS Code.
 		"vscode": {
 			// Set *default* container specific settings.json values on container create.
-			"settings": {},
+			"settings": {
+				"workbench": {
+					"editorAssociations": {
+						"*.md": "vscode.markdown.preview.editor"
+					},
+					"startupEditor": "readme"
+				}
+			},
 			"extensions": [
 				"ms-python.python",
 				"ms-toolsai.jupyter"
-			]
-		},
-
-		// Configure properties specific to Codespaces.
-		"codespaces": {
-			"openFiles": [
-				"README.md",
-				"README.rst"
 			]
 		}
 	}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Open in Leap IDE](
-  https://cdn-assets.cloud.dwavesys.com/shared/latest/badges/leapide.svg)](
-  https://ide.dwavesys.io/#https://github.com/dwave-examples/maximum-cut)
+[![Open in GitHub Codespaces](
+  https://img.shields.io/badge/Open%20in%20GitHub%20Codespaces-333?logo=github)](
+  https://codespaces.new/dwave-examples/maximum-cut?quickstart=1)
 [![Linux/Mac/Windows build status](
   https://circleci.com/gh/dwave-examples/maximum-cut.svg?style=shield)](
   https://circleci.com/gh/dwave-examples/maximum-cut)


### PR DESCRIPTION
- Update `devcontainer.json` to https://github.com/dwavesystems/ocean-devcontainer/commit/f99ab027fa7ec58a5ef5bd8bd4fb646c14dd32fc (v1.1.0)
- Update the readme "Open in" badge to use Codespaces